### PR TITLE
rvalue-reference instead of call by value

### DIFF
--- a/libHh/Vec.h
+++ b/libHh/Vec.h
@@ -130,13 +130,13 @@ template<typename T> using Vec4 = Vec<T,4>;
 
 // Construct an Vec from an immediate list of elements, inferring the element type and array size automatically.
 template<typename T, typename... Ts>
-constexpr Vec<std::decay_t<T>, (1+sizeof...(Ts))> V(const T& t, Ts... ts) {
+constexpr Vec<std::decay_t<T>, (1+sizeof...(Ts))> V(const T& t, Ts&&... ts) {
     return Vec<std::decay_t<T>, 1+sizeof...(ts)>(t,            std::forward<Ts>(ts)...);
 }
 
 // Construct an Vec from an immediate list of elements, inferring the element type and array size automatically.
 template<typename T, typename... Ts>
-constexpr Vec<std::decay_t<T>, (1+sizeof...(Ts))> V(T&& t,      Ts... ts) {
+constexpr Vec<std::decay_t<T>, (1+sizeof...(Ts))> V(T&& t,      Ts&&... ts) {
     return Vec<std::decay_t<T>, 1+sizeof...(ts)>(std::move(t), std::forward<Ts>(ts)...);
 }
 


### PR DESCRIPTION
 if an argument is an lvalue A, we supply the template argument with an lvalue reference to A.
In the original code, if we call V(t, t1) then it will call a copy constructor of Ts and then call a move constructor of Ts. When we change the argument type from Ts to Ts&& we can avoid the move constructor. 
